### PR TITLE
feat(EAV-243): return response body from HTTP SendCommand action

### DIFF
--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -156,9 +156,10 @@ export interface Datastore {
 	}
 }
 
-export interface ActionExecutionResult {
+export type ActionExecutionResult = {
 	result: ActionExecutionResultCode
 	response?: ITranslatableMessage
+	responseData?: unknown
 }
 
 export enum ActionExecutionResultCode {

--- a/packages/timeline-state-resolver/src/integrations/httpSend/AuthenticatedHTTPSendDevice.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/AuthenticatedHTTPSendDevice.ts
@@ -114,7 +114,7 @@ export class AuthenticatedHTTPSendDevice extends HTTPSendDevice {
 		return token
 	}
 
-	async sendCommand({ tlObjId, context, command }: HttpSendDeviceCommand): Promise<void> {
+	async sendCommand({ tlObjId, context, command }: HttpSendDeviceCommand): Promise<unknown> {
 		if (this.authOptions) {
 			const bearerToken =
 				this.authOptions.method === AuthMethod.BEARER_TOKEN ? this.authOptions.bearerToken : await this.tokenPromise

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -97,7 +97,7 @@ export class HTTPSendDevice
 			}
 		}
 
-		await this.sendCommand({
+		const response = await this.sendCommand({
 			tlObjId: '',
 			context: 'makeReady',
 			command: {
@@ -109,6 +109,7 @@ export class HTTPSendDevice
 
 		return {
 			result: ActionExecutionResultCode.Ok,
+			responseData: typeof response === 'string' ? response : undefined,
 		}
 	}
 
@@ -167,7 +168,7 @@ export class HTTPSendDevice
 
 		return commands
 	}
-	async sendCommand({ tlObjId, context, command }: HttpSendDeviceCommand): Promise<void> {
+	async sendCommand({ tlObjId, context, command }: HttpSendDeviceCommand): Promise<unknown> {
 		const commandHash = this.getTrackedStateHash(command)
 
 		if (command.commandName === 'added' || command.commandName === 'changed') {
@@ -229,6 +230,8 @@ export class HTTPSendDevice
 					`HTTPSend: ${command.content.type}: Bad statuscode response on url "${command.content.url}": ${response.statusCode} (${context})`
 				)
 			}
+
+			return response.body
 		} catch (error) {
 			const err = error as RequestError // make typescript happy
 
@@ -266,6 +269,8 @@ export class HTTPSendDevice
 					}, timeLeft)
 				}
 			}
+
+			return err.response?.body
 		}
 	}
 	private getTrackedStateHash(command: HttpSendDeviceCommand['command']): string {


### PR DESCRIPTION
Note: this is a minimal change for release50, which will no longer be needed in release51 because it has this: https://github.com/nrkno/sofie-timeline-state-resolver/pull/298