### PR TITLE
feat(EAV-539): add basic vMix replay support

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -24,6 +24,7 @@ export interface MappingVmixProgram {
 	 * Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)
 	 */
 	index?: 1 | 2 | 3 | 4
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Program
 }
 
@@ -32,6 +33,7 @@ export interface MappingVmixPreview {
 	 * Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)
 	 */
 	index?: 1 | 2 | 3 | 4
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Preview
 }
 
@@ -40,6 +42,7 @@ export interface MappingVmixInput {
 	 * Input number or name. Omit if you plan to use the `filePath` property in `TimelineContentVMixInput`.
 	 */
 	index?: string
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Input
 }
 
@@ -52,6 +55,7 @@ export interface MappingVmixAudioChannel {
 	 * Input layer name
 	 */
 	inputLayer?: string
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.AudioChannel
 }
 
@@ -60,6 +64,7 @@ export interface MappingVmixAudioBus {
 	 * Name (letter) of the bus
 	 */
 	index: 'M' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G'
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.AudioBus
 }
 
@@ -68,6 +73,7 @@ export interface MappingVmixOutput {
 	 * Output
 	 */
 	index: '2' | '3' | '4' | 'External2' | 'Fullscreen' | 'Fullscreen2'
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Output
 }
 
@@ -76,31 +82,48 @@ export interface MappingVmixOverlay {
 	 * Overlay number
 	 */
 	index: 1 | 2 | 3 | 4
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Overlay
 }
 
 export interface MappingVmixRecording {
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Recording
 }
 
 export interface MappingVmixStreaming {
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Streaming
 }
 
 export interface MappingVmixExternal {
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.External
 }
 
 export interface MappingVmixFadeToBlack {
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.FadeToBlack
 }
 
 export interface MappingVmixFader {
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Fader
 }
 
 export interface MappingVmixScript {
+	disableDefaults?: boolean
 	mappingType: MappingVmixType.Script
+}
+
+export interface MappingVmixReplay {
+	disableDefaults?: boolean
+	mappingType: MappingVmixType.Replay
+}
+
+export interface MappingVmixReplayEvent {
+	disableDefaults?: boolean
+	mappingType: MappingVmixType.ReplayEvent
 }
 
 export enum MappingVmixType {
@@ -117,9 +140,11 @@ export enum MappingVmixType {
 	FadeToBlack = 'fadeToBlack',
 	Fader = 'fader',
 	Script = 'script',
+	Replay = 'replay',
+	ReplayEvent = 'replayEvent',
 }
 
-export type SomeMappingVmix = MappingVmixProgram | MappingVmixPreview | MappingVmixInput | MappingVmixAudioChannel | MappingVmixAudioBus | MappingVmixOutput | MappingVmixOverlay | MappingVmixRecording | MappingVmixStreaming | MappingVmixExternal | MappingVmixFadeToBlack | MappingVmixFader | MappingVmixScript
+export type SomeMappingVmix = MappingVmixProgram | MappingVmixPreview | MappingVmixInput | MappingVmixAudioChannel | MappingVmixAudioBus | MappingVmixOutput | MappingVmixOverlay | MappingVmixRecording | MappingVmixStreaming | MappingVmixExternal | MappingVmixFadeToBlack | MappingVmixFader | MappingVmixScript | MappingVmixReplay | MappingVmixReplayEvent
 
 export interface OpenPresetPayload {
 	/**

--- a/packages/timeline-state-resolver-types/src/integrations/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/vmix.ts
@@ -60,6 +60,11 @@ export enum VMixCommand {
 	BROWSER_RELOAD = 'BROWSER_RELOAD',
 	SELECT_INDEX = 'SELECT_INDEX',
 	SET_IMAGE = 'SET_IMAGE',
+	REPLAY_MARK_IN_LIVE = 'REPLAY_MARK_IN_LIVE',
+	REPLAY_MARK_OUT = 'REPLAY_MARK_OUT',
+	REPLAY_SET_LAST_EVENT_TEXT = 'REPLAY_SET_LAST_EVENT_TEXT',
+	REPLAY_START_RECORDING = 'REPLAY_START_RECORDING',
+	REPLAY_STOP_RECORDING = 'REPLAY_STOP_RECORDING',
 }
 
 export type TimelineContentVMixAny =
@@ -76,6 +81,8 @@ export type TimelineContentVMixAny =
 	| TimelineContentVMixOverlay
 	| TimelineContentVMixInput
 	| TimelineContentVMixScript
+	| TimelineContentVMixReplay
+	| TimelineContentVMixReplayEvent
 
 export enum TimelineContentTypeVMix {
 	PROGRAM = 'PROGRAM',
@@ -91,6 +98,8 @@ export enum TimelineContentTypeVMix {
 	EXTERNAL = 'EXTERNAL',
 	OVERLAY = 'OVERLAY',
 	SCRIPT = 'SCRIPT',
+	REPLAY = 'REPLAY',
+	REPLAY_EVENT = 'REPLAY_EVENT',
 }
 export interface TimelineContentVMixBase {
 	deviceType: DeviceType.VMIX
@@ -265,6 +274,18 @@ export interface TimelineContentVMixScript extends TimelineContentVMixBase {
 	type: TimelineContentTypeVMix.SCRIPT
 
 	/** Script name */
+	name: string
+}
+
+export interface TimelineContentVMixReplay extends TimelineContentVMixBase {
+	type: TimelineContentTypeVMix.REPLAY
+
+	recording: boolean
+}
+
+export interface TimelineContentVMixReplayEvent extends TimelineContentVMixBase {
+	type: TimelineContentTypeVMix.REPLAY_EVENT
+
 	name: string
 }
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
@@ -11,7 +11,11 @@
 					"ui:summaryTitle": "Index",
 					"description": "Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)",
 					"enum": [1, 2, 3, 4]
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": [],
 			"additionalProperties": false
@@ -25,7 +29,11 @@
 					"ui:summaryTitle": "Index",
 					"description": "Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)",
 					"enum": [1, 2, 3, 4]
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": [],
 			"additionalProperties": false
@@ -40,7 +48,11 @@
 					"ui:summaryTitle": "Index",
 					"description": "Input number or name. Omit if you plan to use the `filePath` property in `TimelineContentVMixInput`.",
 					"TODO": "string | number. this could be done with 'anyOf' or something, but adds complexity for little benefit"
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": [],
 			"additionalProperties": false
@@ -60,7 +72,11 @@
 					"type": "string",
 					"ui:title": "Input Layer",
 					"description": "Input layer name"
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": [],
 			"additionalProperties": false
@@ -74,7 +90,11 @@
 					"ui:summaryTitle": "Index",
 					"description": "Name (letter) of the bus",
 					"enum": ["M", "A", "B", "C", "D", "E", "F", "G"]
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": ["index"],
 			"additionalProperties": false
@@ -88,7 +108,11 @@
 					"ui:summaryTitle": "Index",
 					"description": "Output",
 					"enum": ["2", "3", "4", "External2", "Fullscreen", "Fullscreen2"]
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": ["index"],
 			"additionalProperties": false
@@ -102,44 +126,100 @@
 					"ui:summaryTitle": "Index",
 					"description": "Overlay number",
 					"enum": [1, 2, 3, 4]
-				}
+				},
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
 			},
 			"required": ["index"],
 			"additionalProperties": false
 		},
 		"recording": {
 			"type": "object",
-			"properties": {},
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
 			"required": [],
 			"additionalProperties": false
 		},
 		"streaming": {
 			"type": "object",
-			"properties": {},
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
 			"required": [],
 			"additionalProperties": false
 		},
 		"external": {
 			"type": "object",
-			"properties": {},
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
 			"required": [],
 			"additionalProperties": false
 		},
 		"fadeToBlack": {
 			"type": "object",
-			"properties": {},
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
 			"required": [],
 			"additionalProperties": false
 		},
 		"fader": {
 			"type": "object",
-			"properties": {},
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
 			"required": [],
 			"additionalProperties": false
 		},
 		"script": {
 			"type": "object",
-			"properties": {},
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
+			"required": [],
+			"additionalProperties": false
+		},
+		"replay": {
+			"type": "object",
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
+			"required": [],
+			"additionalProperties": false
+		},
+		"replayEvent": {
+			"type": "object",
+			"properties": {
+                "disableDefaults": {
+                    "type": "boolean",
+                    "ui:title": "Do not apply default state for this layer"
+                }
+			},
 			"required": [],
 			"additionalProperties": false
 		}

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/mockState.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/mockState.ts
@@ -174,6 +174,7 @@ export function makeMockReportedState(): VMixState {
 				volume: 100,
 			},
 		},
+		replay: undefined,
 	}
 }
 
@@ -190,6 +191,7 @@ export function makeMockFullState(): VMixStateExtended {
 		},
 		runningScripts: [],
 		reportedState: makeMockReportedState(),
+		recordedEventName: undefined,
 	}
 }
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixStateDiffer.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixStateDiffer.spec.ts
@@ -1390,4 +1390,122 @@ describe('VMixStateDiffer', () => {
 			input: '11',
 		})
 	})
+
+	describe('Replay Recording', () => {
+		test('on', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			oldState.reportedState.replay = undefined
+			newState.reportedState.replay = { recording: true }
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(1)
+			expect(commands[0].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_START_RECORDING,
+			})
+		})
+
+		test('off', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			newState.reportedState.replay = { recording: true }
+			newState.reportedState.replay = { recording: false }
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(1)
+			expect(commands[0].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_STOP_RECORDING,
+			})
+		})
+
+		test('same state', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			oldState.reportedState.replay = { recording: true }
+			newState.reportedState.replay = { recording: true }
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(0)
+		})
+
+		test('uncontrolled', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			newState.reportedState.replay = { recording: true }
+			newState.reportedState.replay = undefined
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(0)
+		})
+	})
+
+	describe('Replay Event', () => {
+		test('mark in', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			oldState.recordedEventName = undefined
+			newState.recordedEventName = 'my event'
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(2)
+			expect(commands[0].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_MARK_IN_LIVE,
+			})
+			expect(commands[1].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_SET_LAST_EVENT_TEXT,
+				value: 'my event',
+			})
+		})
+
+		test('mark out', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			oldState.recordedEventName = 'my event'
+			newState.recordedEventName = undefined
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(1)
+			expect(commands[0].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_MARK_OUT,
+			})
+		})
+
+		test('mark out and mark in', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			oldState.recordedEventName = 'my event'
+			newState.recordedEventName = 'my other event'
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(3)
+			expect(commands[0].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_MARK_OUT,
+			})
+			expect(commands[1].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_MARK_IN_LIVE,
+			})
+			expect(commands[2].command).toMatchObject<VMixStateCommand>({
+				command: VMixCommand.REPLAY_SET_LAST_EVENT_TEXT,
+				value: 'my other event',
+			})
+		})
+
+		test('same state', async () => {
+			const { differ, oldState, newState } = createTestEnvironment()
+
+			oldState.recordedEventName = 'my event'
+			newState.recordedEventName = 'my event'
+
+			const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+			expect(commands.length).toBe(0)
+		})
+	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
@@ -331,4 +331,36 @@ describe('VMixTimelineStateConverter', () => {
 		// 	expect(result.reportedState.inputsAddedByUsAudio[prefixAddedInput(filePath)]).toBeDefined()
 		// })
 	})
+
+	describe('replay', () => {
+		it('does not track state when not mapped', () => {
+			const converter = createTestee()
+
+			const result = converter.getVMixStateFromTimelineState(wrapInTimelineState({}), {})
+			expect(result.reportedState.replay).toBe(undefined)
+		})
+
+		it('tracks state for mapped existing inputs', () => {
+			const converter = createTestee()
+
+			const result = converter.getVMixStateFromTimelineState(wrapInTimelineState({}), {
+				replay0: wrapInMapping({
+					mappingType: MappingVmixType.Replay,
+				}),
+			})
+			expect(result.reportedState.replay?.recording).toBe(false)
+		})
+
+		it('does not apply default state when disableDefaults===true', () => {
+			const converter = createTestee()
+
+			const result = converter.getVMixStateFromTimelineState(wrapInTimelineState({}), {
+				replay0: wrapInMapping({
+					mappingType: MappingVmixType.Replay,
+					disableDefaults: true,
+				}),
+			})
+			expect(result.reportedState.replay).toBeUndefined()
+		})
+	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixXmlStateParser.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixXmlStateParser.spec.ts
@@ -142,6 +142,7 @@ describe('VMixXmlStateParser', () => {
 					solo: false,
 				},
 			} as VMixAudioBusesState, // we're parsing a little more, might be useful down the road
+			replay: undefined,
 		})
 	})
 
@@ -334,6 +335,29 @@ describe('VMixXmlStateParser', () => {
 					},
 				},
 			},
+		})
+	})
+
+	it('parses replay', () => {
+		const parser = new VMixXmlStateParser()
+
+		const parsedState = parser.parseVMixState(
+			makeMockVMixXmlState([
+				'<input key="a97b8de1-807a-4c14-8eb9-3de0129b41e3" number="1" type="Capture" title="Cam 0" state="Running" position="0" duration="0" loop="False" muted="False" volume="100" balance="0" solo="False" audiobusses="M" meterF1="0.03034842" meterF2="0.03034842"></input>',
+				`<input key="ca9bc59f-f698-41fe-b17d-1e1743cfee88" number="2" type="Replay" title="Cam 0" state="Running" position="0" duration="0" loop="False" muted="False" volume="100" balance="0" solo="False" audiobusses="M" meterF1="0.03034842" meterF2="0.03034842">
+	gfx.gtzip
+	<replay live="True" recording="True" channelMode="A" events="2" eventsA="2" eventsB="1" cameraA="1" cameraB="1" speed="1" speedA="1" speedB="1">
+		<timecode>2025-04-22T10:14:02.761</timecode>
+		<timecodeA>2025-04-22T10:14:02.761</timecodeA>
+		<timecodeB>2025-04-22T09:54:56.243</timecodeB>
+	</replay>
+</input>`,
+				'<input key="1d70bc59-6517-4571-a0c5-932e30311f01" number="3" type="Capture" title="Cam 2" state="Running" position="0" duration="0" loop="False" muted="False" volume="100" balance="0" solo="False" audiobusses="M" meterF1="0.03034842" meterF2="0.03034842"></input>',
+			])
+		)
+
+		expect(parsedState).toMatchObject<Partial<VMixState>>({
+			replay: { recording: true },
 		})
 	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -274,6 +274,16 @@ export class VMixCommandSender {
 				return this.selectIndex(command.input, command.value)
 			case VMixCommand.SET_IMAGE:
 				return this.setImage(command.input, command.value, command.fieldName)
+			case VMixCommand.REPLAY_MARK_IN_LIVE:
+				return this.replayMarkInLive()
+			case VMixCommand.REPLAY_MARK_OUT:
+				return this.replayMarkOut()
+			case VMixCommand.REPLAY_SET_LAST_EVENT_TEXT:
+				return this.replaySetLastEventText(command.value)
+			case VMixCommand.REPLAY_START_RECORDING:
+				return this.replayStartRecording()
+			case VMixCommand.REPLAY_STOP_RECORDING:
+				return this.replayStopRecording()
 			default:
 				throw new Error(`vmixAPI: Command ${((command || {}) as any).command} not implemented`)
 		}
@@ -522,5 +532,25 @@ export class VMixCommandSender {
 
 	private async sendCommandFunction(func: string, args: SentCommandArgs) {
 		return this.vMixConnection.sendCommandFunction(func, args)
+	}
+
+	public async replayStopRecording(): Promise<any> {
+		return this.sendCommandFunction(`ReplayStopRecording`, {})
+	}
+
+	public async replayStartRecording(): Promise<any> {
+		return this.sendCommandFunction(`ReplayStartRecording`, {})
+	}
+
+	public async replaySetLastEventText(value: string): Promise<any> {
+		return this.sendCommandFunction(`ReplaySetLastEventText`, { value })
+	}
+
+	public async replayMarkOut(): Promise<any> {
+		return this.sendCommandFunction(`ReplayMarkOut`, {})
+	}
+
+	public async replayMarkInLive(): Promise<any> {
+		return this.sendCommandFunction(`ReplayMarkInLive`, {})
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
@@ -243,6 +243,22 @@ export interface VMixStateCommandSetImage extends VMixStateCommandBase {
 	fieldName: string
 	value: string
 }
+export interface VMixStateCommandReplayMarkInLive extends VMixStateCommandBase {
+	command: VMixCommand.REPLAY_MARK_IN_LIVE
+}
+export interface VMixStateCommandReplayMarkOut extends VMixStateCommandBase {
+	command: VMixCommand.REPLAY_MARK_OUT
+}
+export interface VMixStateCommandReplaySetLastEventText extends VMixStateCommandBase {
+	command: VMixCommand.REPLAY_SET_LAST_EVENT_TEXT
+	value: string
+}
+export interface VMixStateCommandReplayStartRecording extends VMixStateCommandBase {
+	command: VMixCommand.REPLAY_START_RECORDING
+}
+export interface VMixStateCommandReplayStopRecording extends VMixStateCommandBase {
+	command: VMixCommand.REPLAY_STOP_RECORDING
+}
 export type VMixStateCommand =
 	| VMixStateCommandPreviewInput
 	| VMixStateCommandTransition
@@ -296,6 +312,11 @@ export type VMixStateCommand =
 	| VMixStateCommandBrowserReload
 	| VMixStateCommanSelectIndex
 	| VMixStateCommandSetImage
+	| VMixStateCommandReplayMarkInLive
+	| VMixStateCommandReplayMarkOut
+	| VMixStateCommandReplaySetLastEventText
+	| VMixStateCommandReplayStartRecording
+	| VMixStateCommandReplayStopRecording
 
 export enum CommandContext {
 	None = 'none',

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
@@ -29,6 +29,11 @@ export interface VMixStateExtended {
 	 */
 	inputLayers: { [key: string]: string }
 	runningScripts: string[]
+	/**
+	 * The name of the currently recorded replay event
+	 * Recording only one event at a time is supported
+	 */
+	recordedEventName: string | undefined
 }
 
 export interface VMixState {
@@ -49,6 +54,7 @@ export interface VMixState {
 	multiCorder: boolean
 	fullscreen: boolean
 	audioBuses: VMixAudioBusesState
+	replay: VMixReplayState | undefined
 }
 
 interface VMixOutputsState {
@@ -135,6 +141,10 @@ interface PreAndPostTransitionCommands {
 	postTransitionCommands: Array<VMixStateCommandWithContext>
 }
 
+export interface VMixReplayState {
+	recording: boolean
+}
+
 export interface VMixDefaultStateFactory {
 	getDefaultState: () => VMixStateExtended
 	getDefaultInputState: (inputIndex: number | string | undefined) => VMixInput
@@ -177,6 +187,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 			this._resolveAddedByUsInputsRemovalState(time, oldVMixState?.reportedState, newVMixState.reportedState)
 		)
 		commands = commands.concat(this._resolveScriptsState(oldVMixState, newVMixState))
+		commands = commands.concat(this._resolveReplayState(oldVMixState, newVMixState))
 
 		return commands
 	}
@@ -210,6 +221,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 					F: undefined,
 					G: undefined,
 				},
+				replay: undefined,
 			},
 			outputs: {
 				'2': undefined,
@@ -221,6 +233,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 			},
 			inputLayers: {},
 			runningScripts: [],
+			recordedEventName: undefined,
 		}
 	}
 
@@ -1073,6 +1086,62 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 				})
 			}
 		})
+		return commands
+	}
+
+	private _resolveReplayState(
+		oldVMixState: VMixStateExtended | undefined,
+		newVMixState: VMixStateExtended
+	): Array<VMixStateCommandWithContext> {
+		const commands: Array<VMixStateCommandWithContext> = []
+		const wasRecording = oldVMixState?.reportedState.replay?.recording
+		const shouldRecord = newVMixState.reportedState.replay?.recording
+		if (wasRecording !== shouldRecord && shouldRecord) {
+			commands.push({
+				command: {
+					command: VMixCommand.REPLAY_START_RECORDING,
+				},
+				context: CommandContext.None,
+				timelineObjId: '',
+			})
+		}
+		if (oldVMixState?.recordedEventName !== newVMixState.recordedEventName) {
+			if (oldVMixState?.recordedEventName !== undefined) {
+				commands.push({
+					command: {
+						command: VMixCommand.REPLAY_MARK_OUT,
+					},
+					context: CommandContext.None,
+					timelineObjId: '',
+				})
+			}
+			if (newVMixState.recordedEventName !== undefined) {
+				commands.push({
+					command: {
+						command: VMixCommand.REPLAY_MARK_IN_LIVE,
+					},
+					context: CommandContext.None,
+					timelineObjId: '',
+				})
+				commands.push({
+					command: {
+						command: VMixCommand.REPLAY_SET_LAST_EVENT_TEXT,
+						value: newVMixState.recordedEventName,
+					},
+					context: CommandContext.None,
+					timelineObjId: '',
+				})
+			}
+		}
+		if (wasRecording !== shouldRecord && shouldRecord === false) {
+			commands.push({
+				command: {
+					command: VMixCommand.REPLAY_STOP_RECORDING,
+				},
+				context: CommandContext.None,
+				timelineObjId: '',
+			})
+		}
 		return commands
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
@@ -36,7 +36,9 @@ const mappingPriority: { [k in MappingVmixType]: number } = {
 	[MappingVmixType.FadeToBlack]: 9,
 	[MappingVmixType.Fader]: 10,
 	[MappingVmixType.Script]: 11,
-	[MappingVmixType.AudioBus]: 11,
+	[MappingVmixType.AudioBus]: 12,
+	[MappingVmixType.Replay]: 13,
+	[MappingVmixType.ReplayEvent]: 15,
 }
 
 export type MappingsVmix = Mappings<SomeMappingVmix>
@@ -183,6 +185,20 @@ export class VMixTimelineStateConverter {
 						existingBus.muted = content.muted ?? existingBus.muted
 						existingBus.volume = content.volume ?? existingBus.volume
 					}
+					break
+				case MappingVmixType.Replay:
+					if (content.type === TimelineContentTypeVMix.REPLAY) {
+						deviceState.reportedState.replay = {
+							...deviceState.reportedState.replay,
+							recording: content.recording,
+						}
+					}
+					break
+				case MappingVmixType.ReplayEvent:
+					if (content.type === TimelineContentTypeVMix.REPLAY_EVENT) {
+						deviceState.recordedEventName = content.name
+					}
+					break
 			}
 		})
 		return deviceState
@@ -262,6 +278,7 @@ export class VMixTimelineStateConverter {
 
 	private _fillStateWithMappingsDefaults(state: VMixStateExtended, mappings: MappingsVmix) {
 		for (const mapping of Object.values<Mapping<SomeMappingVmix>>(mappings)) {
+			if (mapping.options.disableDefaults) continue
 			switch (mapping.options.mappingType) {
 				case MappingVmixType.Program:
 				case MappingVmixType.Preview: {
@@ -307,6 +324,14 @@ export class VMixTimelineStateConverter {
 					break
 				case MappingVmixType.AudioBus:
 					state.reportedState.audioBuses[mapping.options.index] = this.defaultStateFactory.getDefaultAudioBusState()
+					break
+				case MappingVmixType.Replay:
+					state.reportedState.replay = {
+						recording: false,
+					}
+					break
+				case MappingVmixType.ReplayEvent:
+					state.recordedEventName = undefined
 					break
 			}
 		}

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixXmlStateParser.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixXmlStateParser.ts
@@ -8,6 +8,7 @@ import {
 	VMixInput,
 	VMixInputAudio,
 	VMixMix,
+	VMixReplayState,
 	VMixState,
 } from './vMixStateDiffer'
 import { VMixTransitionType } from 'timeline-state-resolver-types'
@@ -28,6 +29,7 @@ export class VMixXmlStateParser {
 		const existingInputsAudio: Record<string, VMixInputAudio> = {}
 		const inputsAddedByUs: Record<string, VMixInput> = {}
 		const inputsAddedByUsAudio: Record<string, VMixInputAudio> = {}
+		let replay: VMixReplayState | undefined
 
 		const inputKeysToNumbers: Record<string, number> = {}
 		for (const input of xmlState['vmix']['inputs']['input']) {
@@ -78,9 +80,11 @@ export class VMixXmlStateParser {
 				})
 			}
 
+			const inputType = input['_attributes']['type']
+
 			const result: VMixInput = {
 				number: inputNumber,
-				type: input['_attributes']['type'],
+				type: inputType,
 				name: isAddedByUs ? title : undefined,
 				state: input['_attributes']['state'],
 				playing: input['_attributes']['state'] === 'Running',
@@ -98,6 +102,12 @@ export class VMixXmlStateParser {
 				listFilePaths: fixedListFilePaths!,
 				text,
 				images,
+			}
+
+			if (inputType === 'Replay') {
+				replay = {
+					recording: input['replay']?.['_attributes']['recording'] === 'True',
+				}
 			}
 
 			const resultAudio = {
@@ -156,6 +166,7 @@ export class VMixXmlStateParser {
 			multiCorder: xmlState['vmix']['multiCorder']['_text'] === 'True',
 			fullscreen: xmlState['vmix']['fullscreen']['_text'] === 'True',
 			audioBuses: this.parseAudioBuses(xmlState),
+			replay,
 		}
 	}
 


### PR DESCRIPTION
In order not to interrupt Replay functionality that might be controlled from elsewhere 
(e.g. rBox), this PR also introduces a `disableDefaults` feature, similar to how the Sisyfos integration works 